### PR TITLE
Add address to array access converter

### DIFF
--- a/mps/04/cachelab.c
+++ b/mps/04/cachelab.c
@@ -98,6 +98,7 @@ void initializeArrayAccessConverter(const char *tracefileName) {
     FILE *file = fopen(filename, "r");
     if (file) {
         int scanned = fscanf(file, "%llx %llx %d %d", &transposeInfo.A, &transposeInfo.B, &transposeInfo.M, &transposeInfo.N);
+        fclose(file);
         if (scanned == 4) {
             transposeInfoStatus = 1;
             return;

--- a/mps/04/cachelab.c
+++ b/mps/04/cachelab.c
@@ -81,3 +81,57 @@ void registerTransFunction(void (*trans)(int M, int N, int[N][M], int[M][N]),
     func_list[func_counter].num_evictions =0;
     func_counter++;
 }
+
+struct TransposeInfo {
+    unsigned long long int A;
+    unsigned long long int B;
+    int M;
+    int N;
+};
+
+static int transposeInfoStatus = 0;
+static struct TransposeInfo transposeInfo;
+
+void initializeArrayAccessConverter(const char *tracefileName) {
+    char filename[4096];
+    sprintf(filename, "%s.info", tracefileName);
+    FILE *file = fopen(filename, "r");
+    if (file) {
+        int scanned = fscanf(file, "%llx %llx %d %d", &transposeInfo.A, &transposeInfo.B, &transposeInfo.M, &transposeInfo.N);
+        if (scanned == 4) {
+            transposeInfoStatus = 1;
+            return;
+        }
+    }
+    transposeInfoStatus = -1;
+}
+
+static int internalAddressToArrayAccess(char *outputString, unsigned long long int address, const struct TransposeInfo *transposeInfo) {
+    if (transposeInfo->N > 0 && transposeInfo->M > 0) {
+        int totalSize = transposeInfo->N * transposeInfo->M;
+        if (address >= transposeInfo->A && address < transposeInfo->A + totalSize * sizeof(int)) {
+            int offset = (int)((address - transposeInfo->A) / sizeof(int));
+            int vPos = offset / transposeInfo->M;
+            int hPos = offset % transposeInfo->M;
+            return sprintf(outputString, "A[%d][%d]", vPos, hPos);
+        }
+        if (address >= transposeInfo->B && address < transposeInfo->B + totalSize * sizeof(int)) {
+            int offset = (int)((address - transposeInfo->B) / sizeof(int));
+            int vPos = offset / transposeInfo->N;
+            int hPos = offset % transposeInfo->N;
+            return sprintf(outputString, "B[%d][%d]", vPos, hPos);
+        }
+    }
+    return sprintf(outputString, "%llx", address);
+}
+
+int addressToArrayAccess(char *outputString, unsigned long long int address) {
+    if (transposeInfoStatus == 0) {
+        fprintf(stderr, "You must call initializeArrayAccessConverter with the input tracefile's name before using addressToArrayAccess!");
+        abort();
+    }
+    if (transposeInfoStatus < 0) {
+        return sprintf(outputString, "%llx", address);
+    }
+    return internalAddressToArrayAccess(outputString, address, &transposeInfo);
+}

--- a/mps/04/cachelab.h
+++ b/mps/04/cachelab.h
@@ -16,13 +16,28 @@ typedef struct trans_func{
   unsigned int num_evictions;
 } trans_func_t;
 
-/* 
+/**
  * printSummary - This function provides a standard way for your cache
  * simulator * to display its final hit and miss statistics
  */ 
 void printSummary(int hits,  /* number of  hits */
-				  int misses, /* number of misses */
-				  int evictions); /* number of evictions */
+                  int misses, /* number of misses */
+                  int evictions); /* number of evictions */
+
+/**
+ * Sets up the array access converter below
+ * Give it the path to the tracefile
+ */
+void initializeArrayAccessConverter(const char *tracefileName);
+
+/**
+ * Converts an address (like 0x006430c0) to an array access (like A[0][0])
+ * Returns the number of characters written
+ * @note Writes the hex form of the address if it isn't a part of A or B
+ * @warning Requires you to run initializeArrayAccessConverter once first
+ */
+int addressToArrayAccess(char *outputString, /* string to write into */
+                         unsigned long long int address /* address to write */ );
 
 /* Fill the matrix with data */
 void initMatrix(int M, int N, int A[N][M], int B[M][N]);

--- a/mps/04/tracegen.c
+++ b/mps/04/tracegen.c
@@ -79,9 +79,11 @@ int main(int argc, char* argv[]){
     /* Record marker addresses */
     FILE* marker_fp = fopen(".marker","w");
     assert(marker_fp);
-    fprintf(marker_fp, "%llx %llx", 
+    fprintf(marker_fp, "%llx %llx %llx %llx",
             (unsigned long long int) &MARKER_START,
-            (unsigned long long int) &MARKER_END );
+            (unsigned long long int) &MARKER_END,
+            (unsigned long long int) A,
+            (unsigned long long int) B );
     fclose(marker_fp);
 
     if (-1==selectedFunc) {


### PR DESCRIPTION
Adds a helper function that converts addresses into array access printouts, allowing people to easily switch their cache simulators from printing this:
```text
L 643694,4 (tag 190d set 14) miss evicting 1a0e
S 683b80,4 (tag 1a0e set 1c) miss evicting 1a0d
L 643698,4 (tag 190d set 14) hit
S 683c80,4 (tag 1a0f set 4) miss evicting 1a0e
L 64369c,4 (tag 190d set 14) hit
S 683d80,4 (tag 1a0f set c) miss evicting 1a0e
```
to this:
```
L A[0][5]: 643694,4 (tag 190d set 14) miss evicting 1a0e (B[4][0] - B[4][7])
S B[5][0]: 683b80,4 (tag 1a0e set 1c) miss evicting 1a0d (B[1][0] - B[1][7])
L A[0][6]: 643698,4 (tag 190d set 14) hit
S B[6][0]: 683c80,4 (tag 1a0f set 4) miss evicting 1a0e (B[2][0] - B[2][7])
L A[0][7]: 64369c,4 (tag 190d set 14) hit
S B[7][0]: 683d80,4 (tag 1a0f set c) miss evicting 1a0e (B[3][0] - B[3][7])
```

They just have to initialize the system by calling
```c
initializeArrayAccessConverter(const char *tracefileName)
```
and then call 
```c
addressToArrayAccess(char *outputString, unsigned long long int address)
```
to write the array notation form of `address` into `outputString`