### PR TITLE
mp05/mdriver: avoid writing too many bytes to a format string

### DIFF
--- a/mps/05/Makefile
+++ b/mps/05/Makefile
@@ -1,6 +1,6 @@
 # Students' Makefile for the Malloc Lab
 CC = gcc
-CFLAGS = -Wall -Werror -g
+CFLAGS = -Wall -Werror -Wno-format-truncation -g
 
 OBJS = mdriver.o mm.o memlib.o fsecs.o fcyc.o clock.o ftimer.o
 

--- a/mps/05/mdriver.c
+++ b/mps/05/mdriver.c
@@ -462,7 +462,7 @@ static trace_t *read_trace(char *tracedir, char *filename)
     strcpy(path, tracedir);
     strcat(path, filename);
     if ((tracefile = fopen(path, "r")) == NULL) {
-	sprintf(msg, "Could not open %s in read_trace", path);
+	snprintf(msg, MAXLINE, "Could not open %s in read_trace", path);
 	unix_error(msg);
     }
     fscanf(tracefile, "%d", &(trace->sugg_heapsize)); /* not used */


### PR DESCRIPTION
this avoids a serious warning about writing too many bytes to a stack buffer,
in favor of a far less serious warning about truncating a string (which we now ignore)

mp05 now compiles successfully.